### PR TITLE
backporting https://github.com/microsoft/DeepSpeed/pull/3370

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -745,9 +745,11 @@ class DeepSpeedEngine(Module):
         res = self._config.communication_data_type
         if res is not None:
             return res
-        elif self.fp16_enabled() or self.zero_optimization_stage():
+
+        if self.fp16_enabled():
             return torch.float16
-        elif self.bfloat16_enabled():
+
+        if self.bfloat16_enabled():
             return torch.bfloat16
 
         return torch.float32

--- a/tests/unit/runtime/test_bf16.py
+++ b/tests/unit/runtime/test_bf16.py
@@ -300,9 +300,11 @@ class TestZeroEmptyGrad(DistributedTest):
                               "fp32"])
 @pytest.mark.parametrize("comm_type",
                          [torch.float16,
-                          torch.bfloat16],
+                          torch.bfloat16,
+                          None],
                          ids=["fp16",
-                              "bfp16"])
+                              "bfp16",
+                              "default"])
 class TestZeroDtypeCocktail(DistributedTest):
     world_size = 2
 
@@ -327,8 +329,11 @@ class TestZeroDtypeCocktail(DistributedTest):
             "zero_optimization": {
                 "stage": 2
             },
-            "communication_data_type": type_str[comm_type]
         }
+        if comm_type is not None:
+            config_dict["communication_data_type"] = type_str[comm_type]
+        else:
+            comm_type = comp_type
         hidden_dim = 10
 
         model = SimpleModel(hidden_dim)


### PR DESCRIPTION
This is to make sure `communication_data_type` defaults to `bfp16` when `bfloat16_enabled=True`.